### PR TITLE
Update default clusters

### DIFF
--- a/examples/auth.js
+++ b/examples/auth.js
@@ -10,7 +10,7 @@ import Feeds from '../src/index';
 const feeds = new Feeds({
   serviceId: 'auth-example-app',
   serviceKey: 'the-id-bit:the-secret-bit',
-  cluster: 'api-staging-ceres.kube.pusherplatform.io'
+  cluster: 'api-staging-ceres.pusherplatform.io'
 });
 
 function hasPermission(userId, feedId) {

--- a/examples/notes-template.html
+++ b/examples/notes-template.html
@@ -50,7 +50,7 @@ function formatTime(timestamp) {
 }
 
 const pusherFeeds = new PusherFeeds({
-  cluster: "api-staging-ceres.kube.pusherplatform.io",
+  cluster: "api-staging-ceres.pusherplatform.io",
   serviceId: "auth-example-app",
 });
 pusherFeeds.feed("newsfeed").subscribe({

--- a/examples/static/client.js
+++ b/examples/static/client.js
@@ -592,7 +592,7 @@ var pusherPlatform = createCommonjsModule(function (module, exports) {
                 };
                 Object.defineProperty(exports, "__esModule", { value: true });
                 var base_client_1 = __webpack_require__(0);
-                var DEFAULT_CLUSTER = "api-ceres.kube.pusherplatform.io";
+                var DEFAULT_CLUSTER = "api-ceres.pusherplatform.io";
                 var App = function () {
                     function App(options) {
                         this.serviceId = options.serviceId;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
 // @flow
-export const defaultCluster = 'api-ceres.kube.pusherplatform.io';
+export const defaultCluster = 'api-ceres.pusherplatform.io';
 export const pathRegex = /^feeds\/([a-zA-Z0-9-]+)\/items$/;
 export const cacheExpiryTolerance = 60;


### PR DESCRIPTION
This PR removes the kube part from the cluster URLs. The staging one doesn't
seem to work yet - which is weird. However, the old "production" one doesn't
work anymore.